### PR TITLE
Date Range Component Prototype

### DIFF
--- a/packages/components/src/date-time/date-range/index.tsx
+++ b/packages/components/src/date-time/date-range/index.tsx
@@ -162,6 +162,7 @@ export function DateRange( {
 						isInvalidDate={ isInvalidDate }
 						isSelected={ isSelected }
 						onMonthPreviewed={ onMonthPreviewed }
+						selectionMode="range"
 						rangeStart={ startDate }
 						rangeEnd={ endDate }
 						setFocusable={ setFocusable }

--- a/packages/components/src/date-time/date-range/index.tsx
+++ b/packages/components/src/date-time/date-range/index.tsx
@@ -24,7 +24,7 @@ import { useState, useEffect } from '@wordpress/element';
  */
 import Calendar from '../date/calendar';
 import type { DateRangeProps } from '../types';
-import { Wrapper } from '../date/styles';
+import { DateRangeWrapper } from '../date/styles';
 import { inputToDate } from '../utils';
 import { TIMEZONELESS_FORMAT } from '../constants';
 
@@ -146,7 +146,7 @@ export function DateRange( {
 	}
 
 	return (
-		<Wrapper
+		<DateRangeWrapper
 			className="components-datetime__date-range"
 			role="application"
 			aria-label={ __( 'Date Range' ) }
@@ -229,7 +229,7 @@ export function DateRange( {
 					/>
 				);
 			} ) }
-		</Wrapper>
+		</DateRangeWrapper>
 	);
 }
 

--- a/packages/components/src/date-time/date-range/index.tsx
+++ b/packages/components/src/date-time/date-range/index.tsx
@@ -4,17 +4,10 @@
 import { useLilius } from 'use-lilius';
 import {
 	format,
-	isSameDay,
 	subMonths,
 	addMonths,
 	startOfDay,
-	isEqual,
-	addDays,
-	subWeeks,
-	addWeeks,
 	isSameMonth,
-	startOfWeek,
-	endOfWeek,
 } from 'date-fns';
 
 /**
@@ -28,15 +21,9 @@ import { useState, useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import Day from '../date/day';
-import type { DatePickerProps } from '../types';
-import {
-	Wrapper,
-	Navigator,
-	NavigatorHeading,
-	Calendar,
-	DayOfWeek,
-} from '../date/styles';
+import Calendar from '../date/calendar';
+import type { DateRangeProps } from '../types';
+import { Wrapper, Navigator, NavigatorHeading } from '../date/styles';
 import { inputToDate } from '../utils';
 import Button from '../../button';
 import { TIMEZONELESS_FORMAT } from '../constants';
@@ -70,13 +57,12 @@ export function DateRange( {
 	startOfWeek: weekStartsOn = 0,
 	rangeStart = null,
 	rangeEnd = null,
-}: DatePickerProps ) {
+}: DateRangeProps ) {
 	const date = currentDate ? inputToDate( currentDate ) : new Date();
 
 	const {
 		calendar,
 		viewing,
-		setSelected,
 		setViewing,
 		isSelected,
 		viewPreviousMonth,
@@ -101,12 +87,6 @@ export function DateRange( {
 	// Used to implement a roving tab index. Tracks the day that receives focus
 	// when the user tabs into the calendar.
 	const [ focusable, setFocusable ] = useState( startOfDay( date ) );
-
-	// Allows us to only programmatically focus() a day when focus was already
-	// within the calendar. This stops us stealing focus from e.g. a TimePicker
-	// input.
-	const [ isFocusWithinCalendar, setIsFocusWithinCalendar ] =
-		useState( false );
 
 	// Update internal state when currentDate prop changes.
 	const [ prevCurrentDate, setPrevCurrentDate ] = useState( currentDate );
@@ -165,113 +145,41 @@ export function DateRange( {
 				/>
 			</Navigator>
 			<Calendar
-				onFocus={ () => setIsFocusWithinCalendar( true ) }
-				onBlur={ () => setIsFocusWithinCalendar( false ) }
-			>
-				{ calendar[ 0 ][ 0 ].map( ( day ) => (
-					<DayOfWeek key={ day.toString() }>
-						{ dateI18n( 'D', day, -day.getTimezoneOffset() ) }
-					</DayOfWeek>
-				) ) }
-				{ calendar[ 0 ].map( ( week ) =>
-					week.map( ( day, index ) => {
-						if ( ! isSameMonth( day, viewing ) ) {
-							return null;
-						}
-						return (
-							<Day
-								key={ day.toString() }
-								day={ day }
-								column={ index + 1 }
-								isSelected={ isSelected( day ) }
-								isFocusable={ isEqual( day, focusable ) }
-								isFocusAllowed={ isFocusWithinCalendar }
-								isToday={ isSameDay( day, new Date() ) }
-								isInvalid={
-									isInvalidDate ? isInvalidDate( day ) : false
-								}
-								numEvents={
-									events.filter( ( event ) =>
-										isSameDay( event.date, day )
-									).length
-								}
-								onClick={ () => {
-									setSelected( [ day ] );
-									setFocusable( day );
-									onChange?.(
-										format(
-											// Don't change the selected date's time fields.
-											new Date(
-												day.getFullYear(),
-												day.getMonth(),
-												day.getDate(),
-												date.getHours(),
-												date.getMinutes(),
-												date.getSeconds(),
-												date.getMilliseconds()
-											),
-											TIMEZONELESS_FORMAT
-										)
-									);
-								} }
-								onKeyDown={ ( event ) => {
-									let nextFocusable;
-									if ( event.key === 'ArrowLeft' ) {
-										nextFocusable = addDays(
-											day,
-											isRTL() ? 1 : -1
-										);
-									}
-									if ( event.key === 'ArrowRight' ) {
-										nextFocusable = addDays(
-											day,
-											isRTL() ? -1 : 1
-										);
-									}
-									if ( event.key === 'ArrowUp' ) {
-										nextFocusable = subWeeks( day, 1 );
-									}
-									if ( event.key === 'ArrowDown' ) {
-										nextFocusable = addWeeks( day, 1 );
-									}
-									if ( event.key === 'PageUp' ) {
-										nextFocusable = subMonths( day, 1 );
-									}
-									if ( event.key === 'PageDown' ) {
-										nextFocusable = addMonths( day, 1 );
-									}
-									if ( event.key === 'Home' ) {
-										nextFocusable = startOfWeek( day );
-									}
-									if ( event.key === 'End' ) {
-										nextFocusable = startOfDay(
-											endOfWeek( day )
-										);
-									}
-									if ( nextFocusable ) {
-										event.preventDefault();
-										setFocusable( nextFocusable );
-										if (
-											! isSameMonth(
-												nextFocusable,
-												viewing
-											)
-										) {
-											setViewing( nextFocusable );
-											onMonthPreviewed?.(
-												format(
-													nextFocusable,
-													TIMEZONELESS_FORMAT
-												)
-											);
-										}
-									}
-								} }
-							/>
+				calendar={ calendar }
+				isInvalidDate={ isInvalidDate }
+				viewing={ viewing }
+				isSelected={ isSelected }
+				events={ events }
+				onDayClick={ ( day ) => {
+					// TODO: Implement range selection.
+					setFocusable( day );
+					const newStartDate = format(
+						// Don't change the selected date's time fields.
+						new Date(
+							day.getFullYear(),
+							day.getMonth(),
+							day.getDate(),
+							date.getHours(),
+							date.getMinutes(),
+							date.getSeconds(),
+							date.getMilliseconds()
+						),
+						TIMEZONELESS_FORMAT
+					);
+					const newEndDate = newStartDate;
+					onChange?.( newStartDate, newEndDate );
+				} }
+				onDayKeyDown={ ( nextFocusable ) => {
+					setFocusable( nextFocusable );
+					if ( ! isSameMonth( nextFocusable, viewing ) ) {
+						setViewing( nextFocusable );
+						onMonthPreviewed?.(
+							format( nextFocusable, TIMEZONELESS_FORMAT )
 						);
-					} )
-				) }
-			</Calendar>
+					}
+				} }
+				focusable={ focusable }
+			/>
 		</Wrapper>
 	);
 }

--- a/packages/components/src/date-time/date-range/index.tsx
+++ b/packages/components/src/date-time/date-range/index.tsx
@@ -214,6 +214,7 @@ export function DateRange( {
 								newEndDate = day;
 							}
 
+							// TODO: only update if changed
 							setPrevStartDate( startDate );
 							setPrevEndDate( endDate );
 

--- a/packages/components/src/date-time/date-range/index.tsx
+++ b/packages/components/src/date-time/date-range/index.tsx
@@ -162,6 +162,8 @@ export function DateRange( {
 						isInvalidDate={ isInvalidDate }
 						isSelected={ isSelected }
 						onMonthPreviewed={ onMonthPreviewed }
+						rangeStart={ startDate }
+						rangeEnd={ endDate }
 						setFocusable={ setFocusable }
 						viewing={ addMonths( viewing, index ) }
 						viewPreviousMonth={ viewPreviousMonth }

--- a/packages/components/src/date-time/date-range/index.tsx
+++ b/packages/components/src/date-time/date-range/index.tsx
@@ -23,12 +23,12 @@ import {
 import { __, isRTL } from '@wordpress/i18n';
 import { arrowLeft, arrowRight } from '@wordpress/icons';
 import { dateI18n } from '@wordpress/date';
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import Day from './day';
+import Day from '../date/day';
 import type { DatePickerProps } from '../types';
 import {
 	Wrapper,
@@ -36,37 +36,40 @@ import {
 	NavigatorHeading,
 	Calendar,
 	DayOfWeek,
-} from './styles';
+} from '../date/styles';
 import { inputToDate } from '../utils';
 import Button from '../../button';
 import { TIMEZONELESS_FORMAT } from '../constants';
 
 /**
- * DatePicker is a React component that renders a calendar for date selection.
+ * DateRange is a React component that renders a calendar for date range selection.
  *
  * ```jsx
- * import { DatePicker } from '@wordpress/components';
+ * import { DateRange } from '@wordpress/components';
  * import { useState } from '@wordpress/element';
  *
- * const MyDatePicker = () => {
+ * const MyDateRange = () => {
  *   const [ date, setDate ] = useState( new Date() );
  *
  *   return (
- *     <DatePicker
- *       currentDate={ date }
+ *     <DateRange
+ *       rangeStart={ date }
+ *       rangeEnd={ date }
  *       onChange={ ( newDate ) => setDate( newDate ) }
  *     />
  *   );
  * };
  * ```
  */
-export function DatePicker( {
-	currentDate,
+export function DateRange( {
+	currentDate, // used to focus the current date in the calendar
 	onChange,
 	events = [],
 	isInvalidDate,
 	onMonthPreviewed,
 	startOfWeek: weekStartsOn = 0,
+	rangeStart = null,
+	rangeEnd = null,
 }: DatePickerProps ) {
 	const date = currentDate ? inputToDate( currentDate ) : new Date();
 
@@ -78,11 +81,22 @@ export function DatePicker( {
 		isSelected,
 		viewPreviousMonth,
 		viewNextMonth,
+		selectRange,
 	} = useLilius( {
-		selected: [ startOfDay( date ) ],
+		selected: [],
 		viewing: startOfDay( date ),
 		weekStartsOn,
 	} );
+
+	useEffect( () => {
+		if ( rangeStart && rangeEnd ) {
+			selectRange(
+				startOfDay( rangeStart ),
+				startOfDay( rangeEnd ),
+				true
+			);
+		}
+	}, [ rangeStart, rangeEnd, selectRange ] );
 
 	// Used to implement a roving tab index. Tracks the day that receives focus
 	// when the user tabs into the calendar.
@@ -98,14 +112,13 @@ export function DatePicker( {
 	const [ prevCurrentDate, setPrevCurrentDate ] = useState( currentDate );
 	if ( currentDate !== prevCurrentDate ) {
 		setPrevCurrentDate( currentDate );
-		setSelected( [ startOfDay( date ) ] );
 		setViewing( startOfDay( date ) );
 		setFocusable( startOfDay( date ) );
 	}
 
 	return (
 		<Wrapper
-			className="components-datetime__date"
+			className="components-datetime__date-range"
 			role="application"
 			aria-label={ __( 'Calendar' ) }
 		>
@@ -263,4 +276,4 @@ export function DatePicker( {
 	);
 }
 
-export default DatePicker;
+export default DateRange;

--- a/packages/components/src/date-time/date-range/index.tsx
+++ b/packages/components/src/date-time/date-range/index.tsx
@@ -151,15 +151,15 @@ export function DateRange( {
 			aria-label={ __( 'Calendar' ) }
 		>
 			<Calendar
+				calendar={ calendar }
+				events={ events }
+				isInvalidDate={ isInvalidDate }
+				isSelected={ isSelected }
+				onMonthPreviewed={ onMonthPreviewed }
+				setFocusable={ setFocusable }
+				viewing={ viewing }
 				viewPreviousMonth={ viewPreviousMonth }
 				viewNextMonth={ viewNextMonth }
-				setFocusable={ setFocusable }
-				onMonthPreviewed={ onMonthPreviewed }
-				calendar={ calendar }
-				isInvalidDate={ isInvalidDate }
-				viewing={ viewing }
-				isSelected={ isSelected }
-				events={ events }
 				onDayClick={ ( day ) => {
 					let newStartDate = startDate,
 						newEndDate = endDate,

--- a/packages/components/src/date-time/date-range/index.tsx
+++ b/packages/components/src/date-time/date-range/index.tsx
@@ -149,7 +149,7 @@ export function DateRange( {
 		<Wrapper
 			className="components-datetime__date-range"
 			role="application"
-			aria-label={ __( 'Calendar' ) }
+			aria-label={ __( 'Date Range' ) }
 		>
 			{ calendar.map( ( month, index ) => {
 				return (

--- a/packages/components/src/date-time/date-range/index.tsx
+++ b/packages/components/src/date-time/date-range/index.tsx
@@ -10,6 +10,7 @@ import {
 	isAfter,
 	isSameDay,
 	intervalToDuration,
+	addMonths,
 } from 'date-fns';
 
 /**
@@ -150,71 +151,84 @@ export function DateRange( {
 			role="application"
 			aria-label={ __( 'Calendar' ) }
 		>
-			<Calendar
-				calendar={ calendar }
-				events={ events }
-				isInvalidDate={ isInvalidDate }
-				isSelected={ isSelected }
-				onMonthPreviewed={ onMonthPreviewed }
-				setFocusable={ setFocusable }
-				viewing={ viewing }
-				viewPreviousMonth={ viewPreviousMonth }
-				viewNextMonth={ viewNextMonth }
-				onDayClick={ ( day ) => {
-					let newStartDate = startDate,
-						newEndDate = endDate,
-						daysFromStartDate,
-						daysFromEndDate;
+			{ calendar.map( ( month, index ) => {
+				return (
+					<Calendar
+						key={ index }
+						calendar={ [ month ] }
+						calendarIndex={ index }
+						events={ events }
+						numberOfMonths={ numberOfMonths }
+						isInvalidDate={ isInvalidDate }
+						isSelected={ isSelected }
+						onMonthPreviewed={ onMonthPreviewed }
+						setFocusable={ setFocusable }
+						viewing={ addMonths( viewing, index ) }
+						viewPreviousMonth={ viewPreviousMonth }
+						viewNextMonth={ viewNextMonth }
+						onDayClick={ ( day ) => {
+							let newStartDate = startDate,
+								newEndDate = endDate,
+								daysFromStartDate,
+								daysFromEndDate;
 
-					if ( newStartDate && newEndDate ) {
-						daysFromStartDate = intervalToDuration( {
-							start: newStartDate,
-							end: day,
-						} );
-						daysFromEndDate = intervalToDuration( {
-							start: day,
-							end: newEndDate,
-						} );
-					}
+							if ( newStartDate && newEndDate ) {
+								daysFromStartDate = intervalToDuration( {
+									start: newStartDate,
+									end: day,
+								} );
+								daysFromEndDate = intervalToDuration( {
+									start: day,
+									end: newEndDate,
+								} );
+							}
 
-					if ( newStartDate && isSameDay( day, newStartDate ) ) {
-						newStartDate = null;
-					} else if ( newEndDate && isSameDay( day, newEndDate ) ) {
-						newEndDate = null;
-					} else if ( ! newStartDate ) {
-						newStartDate = day;
-					} else if ( ! newEndDate ) {
-						newEndDate = day;
-					} else if ( isBefore( day, newStartDate ) ) {
-						newStartDate = day;
-					} else if ( isAfter( day, newEndDate ) ) {
-						newEndDate = day;
-					} else if (
-						daysFromStartDate?.days &&
-						daysFromEndDate?.days &&
-						daysFromStartDate.days < daysFromEndDate.days
-					) {
-						newStartDate = day;
-					} else {
-						newEndDate = day;
-					}
+							if (
+								newStartDate &&
+								isSameDay( day, newStartDate )
+							) {
+								newStartDate = null;
+							} else if (
+								newEndDate &&
+								isSameDay( day, newEndDate )
+							) {
+								newEndDate = null;
+							} else if ( ! newStartDate ) {
+								newStartDate = day;
+							} else if ( ! newEndDate ) {
+								newEndDate = day;
+							} else if ( isBefore( day, newStartDate ) ) {
+								newStartDate = day;
+							} else if ( isAfter( day, newEndDate ) ) {
+								newEndDate = day;
+							} else if (
+								daysFromStartDate?.days &&
+								daysFromEndDate?.days &&
+								daysFromStartDate.days < daysFromEndDate.days
+							) {
+								newStartDate = day;
+							} else {
+								newEndDate = day;
+							}
 
-					setPrevStartDate( startDate );
-					setPrevEndDate( endDate );
+							setPrevStartDate( startDate );
+							setPrevEndDate( endDate );
 
-					setStartDate( newStartDate );
-					setEndDate( newEndDate );
-				} }
-				onDayKeyDown={ ( nextFocusable ) => {
-					if ( ! isSameMonth( nextFocusable, viewing ) ) {
-						setViewing( nextFocusable );
-						onMonthPreviewed?.(
-							format( nextFocusable, TIMEZONELESS_FORMAT )
-						);
-					}
-				} }
-				focusable={ focusable }
-			/>
+							setStartDate( newStartDate );
+							setEndDate( newEndDate );
+						} }
+						onDayKeyDown={ ( nextFocusable ) => {
+							if ( ! isSameMonth( nextFocusable, viewing ) ) {
+								setViewing( nextFocusable );
+								onMonthPreviewed?.(
+									format( nextFocusable, TIMEZONELESS_FORMAT )
+								);
+							}
+						} }
+						focusable={ focusable }
+					/>
+				);
+			} ) }
 		</Wrapper>
 	);
 }

--- a/packages/components/src/date-time/date/calendar.tsx
+++ b/packages/components/src/date-time/date/calendar.tsx
@@ -1,0 +1,140 @@
+/**
+ * External dependencies
+ */
+import {
+	isSameDay,
+	subMonths,
+	addMonths,
+	startOfDay,
+	isEqual,
+	addDays,
+	subWeeks,
+	addWeeks,
+	isSameMonth,
+	startOfWeek,
+	endOfWeek,
+} from 'date-fns';
+
+/**
+ * WordPress dependencies
+ */
+import { isRTL } from '@wordpress/i18n';
+import { dateI18n } from '@wordpress/date';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Day from './day';
+import { Calendar as StyledCalendar, DayOfWeek } from './styles';
+
+type CalendarProps = {
+	calendar: Date[][][];
+	isInvalidDate?: ( date: Date ) => boolean;
+	viewing: Date;
+	isSelected: ( date: Date ) => boolean;
+	onDayClick?: ( date: Date ) => void;
+	onDayKeyDown?: ( date: Date ) => void;
+	focusable: Date;
+	events: { date: Date }[];
+};
+
+export function Calendar( {
+	calendar,
+	isInvalidDate,
+	viewing,
+	isSelected,
+	onDayClick,
+	onDayKeyDown,
+	focusable,
+	events,
+}: CalendarProps ) {
+	// Allows us to only programmatically focus() a day when focus was already
+	// within the calendar. This stops us stealing focus from e.g. a TimePicker
+	// input.
+	const [ isFocusWithinCalendar, setIsFocusWithinCalendar ] =
+		useState( false );
+
+	return (
+		<StyledCalendar
+			onFocus={ () => setIsFocusWithinCalendar( true ) }
+			onBlur={ () => setIsFocusWithinCalendar( false ) }
+		>
+			{ calendar[ 0 ][ 0 ].map( ( day ) => (
+				<DayOfWeek key={ day.toString() }>
+					{ dateI18n( 'D', day, -day.getTimezoneOffset() ) }
+				</DayOfWeek>
+			) ) }
+			{ calendar[ 0 ].map( ( week ) =>
+				week.map( ( day, index ) => {
+					if ( ! isSameMonth( day, viewing ) ) {
+						return null;
+					}
+					return (
+						<Day
+							key={ day.toString() }
+							day={ day }
+							column={ index + 1 }
+							isSelected={ isSelected( day ) }
+							isFocusable={ isEqual( day, focusable ) }
+							isFocusAllowed={ isFocusWithinCalendar }
+							isToday={ isSameDay( day, new Date() ) }
+							isInvalid={
+								isInvalidDate ? isInvalidDate( day ) : false
+							}
+							numEvents={
+								events.filter( ( event ) =>
+									isSameDay( event.date, day )
+								).length
+							}
+							onClick={ () => {
+								onDayClick?.( day );
+							} }
+							onKeyDown={ ( event ) => {
+								let nextFocusable;
+								if ( event.key === 'ArrowLeft' ) {
+									nextFocusable = addDays(
+										day,
+										isRTL() ? 1 : -1
+									);
+								}
+								if ( event.key === 'ArrowRight' ) {
+									nextFocusable = addDays(
+										day,
+										isRTL() ? -1 : 1
+									);
+								}
+								if ( event.key === 'ArrowUp' ) {
+									nextFocusable = subWeeks( day, 1 );
+								}
+								if ( event.key === 'ArrowDown' ) {
+									nextFocusable = addWeeks( day, 1 );
+								}
+								if ( event.key === 'PageUp' ) {
+									nextFocusable = subMonths( day, 1 );
+								}
+								if ( event.key === 'PageDown' ) {
+									nextFocusable = addMonths( day, 1 );
+								}
+								if ( event.key === 'Home' ) {
+									nextFocusable = startOfWeek( day );
+								}
+								if ( event.key === 'End' ) {
+									nextFocusable = startOfDay(
+										endOfWeek( day )
+									);
+								}
+								if ( nextFocusable ) {
+									event.preventDefault();
+									onDayKeyDown?.( nextFocusable );
+								}
+							} }
+						/>
+					);
+				} )
+			) }
+		</StyledCalendar>
+	);
+}
+
+export default Calendar;

--- a/packages/components/src/date-time/date/calendar.tsx
+++ b/packages/components/src/date-time/date/calendar.tsx
@@ -53,6 +53,8 @@ type CalendarProps = {
 	onMonthPreviewed?: ( date: string ) => void;
 	calendarIndex?: number;
 	numberOfMonths?: number;
+	rangeStart?: Date | null;
+	rangeEnd?: Date | null;
 };
 
 export function Calendar( {
@@ -70,6 +72,8 @@ export function Calendar( {
 	onMonthPreviewed,
 	calendarIndex = 0,
 	numberOfMonths = 1,
+	rangeStart = null,
+	rangeEnd = null,
 }: CalendarProps ) {
 	// Allows us to only programmatically focus() a day when focus was already
 	// within the calendar. This stops us stealing focus from e.g. a TimePicker
@@ -159,6 +163,14 @@ export function Calendar( {
 								isToday={ isSameDay( day, new Date() ) }
 								isInvalid={
 									isInvalidDate ? isInvalidDate( day ) : false
+								}
+								isBoundary={
+									!! (
+										( rangeStart &&
+											isSameDay( day, rangeStart ) ) ||
+										( rangeEnd &&
+											isSameDay( day, rangeEnd ) )
+									)
 								}
 								numEvents={
 									events.filter( ( event ) =>

--- a/packages/components/src/date-time/date/calendar.tsx
+++ b/packages/components/src/date-time/date/calendar.tsx
@@ -84,23 +84,24 @@ export function Calendar( {
 			aria-label={ __( 'Calendar' ) }
 		>
 			<Navigator>
-				{ calendarIndex === 0 && (
-					<Button
-						icon={ isRTL() ? arrowRight : arrowLeft }
-						variant="tertiary"
-						aria-label={ __( 'View previous month' ) }
-						onClick={ () => {
-							viewPreviousMonth();
-							setFocusable( subMonths( focusable, 1 ) );
-							onMonthPreviewed?.(
-								format(
-									subMonths( viewing, 1 ),
-									TIMEZONELESS_FORMAT
-								)
-							);
-						} }
-					/>
-				) }
+				<Button
+					style={ {
+						visibility: calendarIndex === 0 ? 'visible' : 'hidden',
+					} }
+					icon={ isRTL() ? arrowRight : arrowLeft }
+					variant="tertiary"
+					aria-label={ __( 'View previous month' ) }
+					onClick={ () => {
+						viewPreviousMonth();
+						setFocusable( subMonths( focusable, 1 ) );
+						onMonthPreviewed?.(
+							format(
+								subMonths( viewing, 1 ),
+								TIMEZONELESS_FORMAT
+							)
+						);
+					} }
+				/>
 				<NavigatorHeading level={ 3 }>
 					<strong>
 						{ dateI18n(
@@ -111,23 +112,27 @@ export function Calendar( {
 					</strong>{ ' ' }
 					{ dateI18n( 'Y', viewing, -viewing.getTimezoneOffset() ) }
 				</NavigatorHeading>
-				{ calendarIndex === numberOfMonths - 1 && (
-					<Button
-						icon={ isRTL() ? arrowLeft : arrowRight }
-						variant="tertiary"
-						aria-label={ __( 'View next month' ) }
-						onClick={ () => {
-							viewNextMonth();
-							setFocusable( addMonths( focusable, 1 ) );
-							onMonthPreviewed?.(
-								format(
-									addMonths( viewing, 1 ),
-									TIMEZONELESS_FORMAT
-								)
-							);
-						} }
-					/>
-				) }
+				<Button
+					style={ {
+						visibility:
+							calendarIndex === numberOfMonths - 1
+								? 'visible'
+								: 'hidden',
+					} }
+					icon={ isRTL() ? arrowLeft : arrowRight }
+					variant="tertiary"
+					aria-label={ __( 'View next month' ) }
+					onClick={ () => {
+						viewNextMonth();
+						setFocusable( addMonths( focusable, 1 ) );
+						onMonthPreviewed?.(
+							format(
+								addMonths( viewing, 1 ),
+								TIMEZONELESS_FORMAT
+							)
+						);
+					} }
+				/>
 			</Navigator>
 			<StyledCalendar
 				onFocus={ () => setIsFocusWithinCalendar( true ) }

--- a/packages/components/src/date-time/date/calendar.tsx
+++ b/packages/components/src/date-time/date/calendar.tsx
@@ -33,6 +33,7 @@ import {
 	DayOfWeek,
 	Navigator,
 	NavigatorHeading,
+	Wrapper,
 } from './styles';
 import { TIMEZONELESS_FORMAT } from '../constants';
 import Button from '../../button';
@@ -77,7 +78,11 @@ export function Calendar( {
 		useState( false );
 
 	return (
-		<>
+		<Wrapper
+			className="components-datetime__date"
+			role="application"
+			aria-label={ __( 'Calendar' ) }
+		>
 			<Navigator>
 				{ calendarIndex === 0 && (
 					<Button
@@ -204,7 +209,7 @@ export function Calendar( {
 					} )
 				) }
 			</StyledCalendar>
-		</>
+		</Wrapper>
 	);
 }
 

--- a/packages/components/src/date-time/date/calendar.tsx
+++ b/packages/components/src/date-time/date/calendar.tsx
@@ -55,6 +55,7 @@ type CalendarProps = {
 	numberOfMonths?: number;
 	rangeStart?: Date | null;
 	rangeEnd?: Date | null;
+	selectionMode?: 'single' | 'range';
 };
 
 export function Calendar( {
@@ -74,6 +75,7 @@ export function Calendar( {
 	numberOfMonths = 1,
 	rangeStart = null,
 	rangeEnd = null,
+	selectionMode = 'single',
 }: CalendarProps ) {
 	// Allows us to only programmatically focus() a day when focus was already
 	// within the calendar. This stops us stealing focus from e.g. a TimePicker
@@ -161,6 +163,7 @@ export function Calendar( {
 								isFocusable={ isEqual( day, focusable ) }
 								isFocusAllowed={ isFocusWithinCalendar }
 								isToday={ isSameDay( day, new Date() ) }
+								selectionMode={ selectionMode }
 								isInvalid={
 									isInvalidDate ? isInvalidDate( day ) : false
 								}

--- a/packages/components/src/date-time/date/calendar.tsx
+++ b/packages/components/src/date-time/date/calendar.tsx
@@ -13,12 +13,14 @@ import {
 	isSameMonth,
 	startOfWeek,
 	endOfWeek,
+	format,
 } from 'date-fns';
 
 /**
  * WordPress dependencies
  */
-import { isRTL } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
+import { arrowLeft, arrowRight } from '@wordpress/icons';
 import { dateI18n } from '@wordpress/date';
 import { useState } from '@wordpress/element';
 
@@ -26,7 +28,14 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import Day from './day';
-import { Calendar as StyledCalendar, DayOfWeek } from './styles';
+import {
+	Calendar as StyledCalendar,
+	DayOfWeek,
+	Navigator,
+	NavigatorHeading,
+} from './styles';
+import { TIMEZONELESS_FORMAT } from '../constants';
+import Button from '../../button';
 
 type CalendarProps = {
 	calendar: Date[][][];
@@ -37,6 +46,12 @@ type CalendarProps = {
 	onDayKeyDown?: ( date: Date ) => void;
 	focusable: Date;
 	events: { date: Date }[];
+	viewPreviousMonth: () => void;
+	viewNextMonth: () => void;
+	setFocusable: React.Dispatch< React.SetStateAction< Date > >;
+	onMonthPreviewed?: ( date: string ) => void;
+	calendarIndex?: number;
+	numberOfMonths?: number;
 };
 
 export function Calendar( {
@@ -48,6 +63,12 @@ export function Calendar( {
 	onDayKeyDown,
 	focusable,
 	events,
+	viewPreviousMonth,
+	viewNextMonth,
+	setFocusable,
+	onMonthPreviewed,
+	calendarIndex = 0,
+	numberOfMonths = 1,
 }: CalendarProps ) {
 	// Allows us to only programmatically focus() a day when focus was already
 	// within the calendar. This stops us stealing focus from e.g. a TimePicker
@@ -56,84 +77,134 @@ export function Calendar( {
 		useState( false );
 
 	return (
-		<StyledCalendar
-			onFocus={ () => setIsFocusWithinCalendar( true ) }
-			onBlur={ () => setIsFocusWithinCalendar( false ) }
-		>
-			{ calendar[ 0 ][ 0 ].map( ( day ) => (
-				<DayOfWeek key={ day.toString() }>
-					{ dateI18n( 'D', day, -day.getTimezoneOffset() ) }
-				</DayOfWeek>
-			) ) }
-			{ calendar[ 0 ].map( ( week ) =>
-				week.map( ( day, index ) => {
-					if ( ! isSameMonth( day, viewing ) ) {
-						return null;
-					}
-					return (
-						<Day
-							key={ day.toString() }
-							day={ day }
-							column={ index + 1 }
-							isSelected={ isSelected( day ) }
-							isFocusable={ isEqual( day, focusable ) }
-							isFocusAllowed={ isFocusWithinCalendar }
-							isToday={ isSameDay( day, new Date() ) }
-							isInvalid={
-								isInvalidDate ? isInvalidDate( day ) : false
-							}
-							numEvents={
-								events.filter( ( event ) =>
-									isSameDay( event.date, day )
-								).length
-							}
-							onClick={ () => {
-								onDayClick?.( day );
-							} }
-							onKeyDown={ ( event ) => {
-								let nextFocusable;
-								if ( event.key === 'ArrowLeft' ) {
-									nextFocusable = addDays(
-										day,
-										isRTL() ? 1 : -1
-									);
+		<>
+			<Navigator>
+				{ calendarIndex === 0 && (
+					<Button
+						icon={ isRTL() ? arrowRight : arrowLeft }
+						variant="tertiary"
+						aria-label={ __( 'View previous month' ) }
+						onClick={ () => {
+							viewPreviousMonth();
+							setFocusable( subMonths( focusable, 1 ) );
+							onMonthPreviewed?.(
+								format(
+									subMonths( viewing, 1 ),
+									TIMEZONELESS_FORMAT
+								)
+							);
+						} }
+					/>
+				) }
+				<NavigatorHeading level={ 3 }>
+					<strong>
+						{ dateI18n(
+							'F',
+							viewing,
+							-viewing.getTimezoneOffset()
+						) }
+					</strong>{ ' ' }
+					{ dateI18n( 'Y', viewing, -viewing.getTimezoneOffset() ) }
+				</NavigatorHeading>
+				{ calendarIndex === numberOfMonths - 1 && (
+					<Button
+						icon={ isRTL() ? arrowLeft : arrowRight }
+						variant="tertiary"
+						aria-label={ __( 'View next month' ) }
+						onClick={ () => {
+							viewNextMonth();
+							setFocusable( addMonths( focusable, 1 ) );
+							onMonthPreviewed?.(
+								format(
+									addMonths( viewing, 1 ),
+									TIMEZONELESS_FORMAT
+								)
+							);
+						} }
+					/>
+				) }
+			</Navigator>
+			<StyledCalendar
+				onFocus={ () => setIsFocusWithinCalendar( true ) }
+				onBlur={ () => setIsFocusWithinCalendar( false ) }
+			>
+				{ calendar[ 0 ][ 0 ].map( ( day ) => (
+					<DayOfWeek key={ day.toString() }>
+						{ dateI18n( 'D', day, -day.getTimezoneOffset() ) }
+					</DayOfWeek>
+				) ) }
+				{ calendar[ 0 ].map( ( week ) =>
+					week.map( ( day, index ) => {
+						if ( ! isSameMonth( day, viewing ) ) {
+							return null;
+						}
+						return (
+							<Day
+								key={ day.toString() }
+								day={ day }
+								column={ index + 1 }
+								isSelected={ isSelected( day ) }
+								isFocusable={ isEqual( day, focusable ) }
+								isFocusAllowed={ isFocusWithinCalendar }
+								isToday={ isSameDay( day, new Date() ) }
+								isInvalid={
+									isInvalidDate ? isInvalidDate( day ) : false
 								}
-								if ( event.key === 'ArrowRight' ) {
-									nextFocusable = addDays(
-										day,
-										isRTL() ? -1 : 1
-									);
+								numEvents={
+									events.filter( ( event ) =>
+										isSameDay( event.date, day )
+									).length
 								}
-								if ( event.key === 'ArrowUp' ) {
-									nextFocusable = subWeeks( day, 1 );
-								}
-								if ( event.key === 'ArrowDown' ) {
-									nextFocusable = addWeeks( day, 1 );
-								}
-								if ( event.key === 'PageUp' ) {
-									nextFocusable = subMonths( day, 1 );
-								}
-								if ( event.key === 'PageDown' ) {
-									nextFocusable = addMonths( day, 1 );
-								}
-								if ( event.key === 'Home' ) {
-									nextFocusable = startOfWeek( day );
-								}
-								if ( event.key === 'End' ) {
-									nextFocusable = startOfDay(
-										endOfWeek( day )
-									);
-								}
-								if ( nextFocusable ) {
-									event.preventDefault();
-									onDayKeyDown?.( nextFocusable );
-								}
-							} }
-						/>
-					);
-				} )
-			) }
-		</StyledCalendar>
+								onClick={ () => {
+									setFocusable?.( day );
+									onDayClick?.( day );
+								} }
+								onKeyDown={ ( event ) => {
+									let nextFocusable;
+									if ( event.key === 'ArrowLeft' ) {
+										nextFocusable = addDays(
+											day,
+											isRTL() ? 1 : -1
+										);
+									}
+									if ( event.key === 'ArrowRight' ) {
+										nextFocusable = addDays(
+											day,
+											isRTL() ? -1 : 1
+										);
+									}
+									if ( event.key === 'ArrowUp' ) {
+										nextFocusable = subWeeks( day, 1 );
+									}
+									if ( event.key === 'ArrowDown' ) {
+										nextFocusable = addWeeks( day, 1 );
+									}
+									if ( event.key === 'PageUp' ) {
+										nextFocusable = subMonths( day, 1 );
+									}
+									if ( event.key === 'PageDown' ) {
+										nextFocusable = addMonths( day, 1 );
+									}
+									if ( event.key === 'Home' ) {
+										nextFocusable = startOfWeek( day );
+									}
+									if ( event.key === 'End' ) {
+										nextFocusable = startOfDay(
+											endOfWeek( day )
+										);
+									}
+									if ( nextFocusable ) {
+										event.preventDefault();
+										setFocusable( nextFocusable );
+										onDayKeyDown?.( nextFocusable );
+									}
+								} }
+							/>
+						);
+					} )
+				) }
+			</StyledCalendar>
+		</>
 	);
 }
 

--- a/packages/components/src/date-time/date/day.tsx
+++ b/packages/components/src/date-time/date/day.tsx
@@ -13,7 +13,7 @@ import { useRef, useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { DayButton } from './styles';
+import { ButtonWrapper, DayButton } from './styles';
 
 type DayProps = {
 	day: Date;
@@ -26,6 +26,7 @@ type DayProps = {
 	isInvalid: boolean;
 	onClick: () => void;
 	onKeyDown: KeyboardEventHandler;
+	isBoundary?: boolean;
 };
 
 function Day( {
@@ -39,6 +40,7 @@ function Day( {
 	numEvents,
 	onClick,
 	onKeyDown,
+	isBoundary = false,
 }: DayProps ) {
 	const ref = useRef< HTMLButtonElement >();
 
@@ -55,21 +57,23 @@ function Day( {
 	}, [ isFocusable ] );
 
 	return (
-		<DayButton
-			ref={ ref }
-			className="components-datetime__date__day" // Unused, for backwards compatibility.
-			disabled={ isInvalid }
-			tabIndex={ isFocusable ? 0 : -1 }
-			aria-label={ getDayLabel( day, isSelected, numEvents ) }
-			column={ column }
-			isSelected={ isSelected }
-			isToday={ isToday }
-			hasEvents={ numEvents > 0 }
-			onClick={ onClick }
-			onKeyDown={ onKeyDown }
-		>
-			{ dateI18n( 'j', day, -day.getTimezoneOffset() ) }
-		</DayButton>
+		<ButtonWrapper isSelected={ isSelected } isBoundary={ isBoundary }>
+			<DayButton
+				ref={ ref }
+				className="components-datetime__date__day" // Unused, for backwards compatibility.
+				disabled={ isInvalid }
+				tabIndex={ isFocusable ? 0 : -1 }
+				aria-label={ getDayLabel( day, isSelected, numEvents ) }
+				column={ column }
+				isSelected={ isSelected }
+				isToday={ isToday }
+				hasEvents={ numEvents > 0 }
+				onClick={ onClick }
+				onKeyDown={ onKeyDown }
+			>
+				{ dateI18n( 'j', day, -day.getTimezoneOffset() ) }
+			</DayButton>
+		</ButtonWrapper>
 	);
 }
 

--- a/packages/components/src/date-time/date/day.tsx
+++ b/packages/components/src/date-time/date/day.tsx
@@ -27,6 +27,7 @@ type DayProps = {
 	onClick: () => void;
 	onKeyDown: KeyboardEventHandler;
 	isBoundary?: boolean;
+	selectionMode?: 'single' | 'range';
 };
 
 function Day( {
@@ -41,6 +42,7 @@ function Day( {
 	onClick,
 	onKeyDown,
 	isBoundary = false,
+	selectionMode = 'single',
 }: DayProps ) {
 	const ref = useRef< HTMLButtonElement >();
 
@@ -57,7 +59,12 @@ function Day( {
 	}, [ isFocusable ] );
 
 	return (
-		<ButtonWrapper isSelected={ isSelected } isBoundary={ isBoundary }>
+		<ButtonWrapper
+			isSelected={ isSelected }
+			isBoundary={ isBoundary }
+			selectionMode={ selectionMode }
+			isToday={ isToday }
+		>
 			<DayButton
 				ref={ ref }
 				className="components-datetime__date__day" // Unused, for backwards compatibility.
@@ -70,6 +77,7 @@ function Day( {
 				hasEvents={ numEvents > 0 }
 				onClick={ onClick }
 				onKeyDown={ onKeyDown }
+				selectionMode={ selectionMode }
 			>
 				{ dateI18n( 'j', day, -day.getTimezoneOffset() ) }
 			</DayButton>

--- a/packages/components/src/date-time/date/day.tsx
+++ b/packages/components/src/date-time/date/day.tsx
@@ -1,0 +1,115 @@
+/**
+ * External dependencies
+ */
+import type { KeyboardEventHandler } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { dateI18n, getSettings } from '@wordpress/date';
+import { useRef, useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { DayButton } from './styles';
+
+type DayProps = {
+	day: Date;
+	column: number;
+	isSelected: boolean;
+	isFocusable: boolean;
+	isFocusAllowed: boolean;
+	isToday: boolean;
+	numEvents: number;
+	isInvalid: boolean;
+	onClick: () => void;
+	onKeyDown: KeyboardEventHandler;
+};
+
+function Day( {
+	day,
+	column,
+	isSelected,
+	isFocusable,
+	isFocusAllowed,
+	isToday,
+	isInvalid,
+	numEvents,
+	onClick,
+	onKeyDown,
+}: DayProps ) {
+	const ref = useRef< HTMLButtonElement >();
+
+	// Focus the day when it becomes focusable, e.g. because an arrow key is
+	// pressed. Only do this if focus is allowed - this stops us stealing focus
+	// from e.g. a TimePicker input.
+	useEffect( () => {
+		if ( ref.current && isFocusable && isFocusAllowed ) {
+			ref.current.focus();
+		}
+		// isFocusAllowed is not a dep as there is no point calling focus() on
+		// an already focused element.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ isFocusable ] );
+
+	return (
+		<DayButton
+			ref={ ref }
+			className="components-datetime__date__day" // Unused, for backwards compatibility.
+			disabled={ isInvalid }
+			tabIndex={ isFocusable ? 0 : -1 }
+			aria-label={ getDayLabel( day, isSelected, numEvents ) }
+			column={ column }
+			isSelected={ isSelected }
+			isToday={ isToday }
+			hasEvents={ numEvents > 0 }
+			onClick={ onClick }
+			onKeyDown={ onKeyDown }
+		>
+			{ dateI18n( 'j', day, -day.getTimezoneOffset() ) }
+		</DayButton>
+	);
+}
+
+function getDayLabel( date: Date, isSelected: boolean, numEvents: number ) {
+	const { formats } = getSettings();
+	const localizedDate = dateI18n(
+		formats.date,
+		date,
+		-date.getTimezoneOffset()
+	);
+	if ( isSelected && numEvents > 0 ) {
+		return sprintf(
+			// translators: 1: The calendar date. 2: Number of events on the calendar date.
+			_n(
+				'%1$s. Selected. There is %2$d event',
+				'%1$s. Selected. There are %2$d events',
+				numEvents
+			),
+			localizedDate,
+			numEvents
+		);
+	} else if ( isSelected ) {
+		return sprintf(
+			// translators: %s: The calendar date.
+			__( '%1$s. Selected' ),
+			localizedDate
+		);
+	} else if ( numEvents > 0 ) {
+		return sprintf(
+			// translators: 1: The calendar date. 2: Number of events on the calendar date.
+			_n(
+				'%1$s. There is %2$d event',
+				'%1$s. There are %2$d events',
+				numEvents
+			),
+			localizedDate,
+			numEvents
+		);
+	}
+	return localizedDate;
+}
+
+export default Day;

--- a/packages/components/src/date-time/date/index.tsx
+++ b/packages/components/src/date-time/date/index.tsx
@@ -7,7 +7,6 @@ import { format, startOfDay, isSameMonth } from 'date-fns';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 
 /**
@@ -15,7 +14,6 @@ import { useState } from '@wordpress/element';
  */
 import Calendar from './calendar';
 import type { DatePickerProps } from '../types';
-import { Wrapper } from './styles';
 import { inputToDate } from '../utils';
 import { TIMEZONELESS_FORMAT } from '../constants';
 
@@ -76,50 +74,44 @@ export function DatePicker( {
 	}
 
 	return (
-		<Wrapper
-			className="components-datetime__date"
-			role="application"
-			aria-label={ __( 'Calendar' ) }
-		>
-			<Calendar
-				calendar={ calendar }
-				events={ events }
-				isInvalidDate={ isInvalidDate }
-				isSelected={ isSelected }
-				onMonthPreviewed={ onMonthPreviewed }
-				setFocusable={ setFocusable }
-				viewing={ viewing }
-				viewPreviousMonth={ viewPreviousMonth }
-				viewNextMonth={ viewNextMonth }
-				onDayClick={ ( day ) => {
-					setSelected( [ day ] );
-					onChange?.(
-						format(
-							// Don't change the selected date's time fields.
-							new Date(
-								day.getFullYear(),
-								day.getMonth(),
-								day.getDate(),
-								date.getHours(),
-								date.getMinutes(),
-								date.getSeconds(),
-								date.getMilliseconds()
-							),
-							TIMEZONELESS_FORMAT
-						)
+		<Calendar
+			calendar={ calendar }
+			events={ events }
+			isInvalidDate={ isInvalidDate }
+			isSelected={ isSelected }
+			onMonthPreviewed={ onMonthPreviewed }
+			setFocusable={ setFocusable }
+			viewing={ viewing }
+			viewPreviousMonth={ viewPreviousMonth }
+			viewNextMonth={ viewNextMonth }
+			onDayClick={ ( day ) => {
+				setSelected( [ day ] );
+				onChange?.(
+					format(
+						// Don't change the selected date's time fields.
+						new Date(
+							day.getFullYear(),
+							day.getMonth(),
+							day.getDate(),
+							date.getHours(),
+							date.getMinutes(),
+							date.getSeconds(),
+							date.getMilliseconds()
+						),
+						TIMEZONELESS_FORMAT
+					)
+				);
+			} }
+			onDayKeyDown={ ( nextFocusable ) => {
+				if ( ! isSameMonth( nextFocusable, viewing ) ) {
+					setViewing( nextFocusable );
+					onMonthPreviewed?.(
+						format( nextFocusable, TIMEZONELESS_FORMAT )
 					);
-				} }
-				onDayKeyDown={ ( nextFocusable ) => {
-					if ( ! isSameMonth( nextFocusable, viewing ) ) {
-						setViewing( nextFocusable );
-						onMonthPreviewed?.(
-							format( nextFocusable, TIMEZONELESS_FORMAT )
-						);
-					}
-				} }
-				focusable={ focusable }
-			/>
-		</Wrapper>
+				}
+			} }
+			focusable={ focusable }
+		/>
 	);
 }
 

--- a/packages/components/src/date-time/date/index.tsx
+++ b/packages/components/src/date-time/date/index.tsx
@@ -82,15 +82,15 @@ export function DatePicker( {
 			aria-label={ __( 'Calendar' ) }
 		>
 			<Calendar
+				calendar={ calendar }
+				events={ events }
+				isInvalidDate={ isInvalidDate }
+				isSelected={ isSelected }
+				onMonthPreviewed={ onMonthPreviewed }
+				setFocusable={ setFocusable }
+				viewing={ viewing }
 				viewPreviousMonth={ viewPreviousMonth }
 				viewNextMonth={ viewNextMonth }
-				setFocusable={ setFocusable }
-				onMonthPreviewed={ onMonthPreviewed }
-				calendar={ calendar }
-				isInvalidDate={ isInvalidDate }
-				viewing={ viewing }
-				isSelected={ isSelected }
-				events={ events }
 				onDayClick={ ( day ) => {
 					setSelected( [ day ] );
 					onChange?.(

--- a/packages/components/src/date-time/date/index.tsx
+++ b/packages/components/src/date-time/date/index.tsx
@@ -2,20 +2,12 @@
  * External dependencies
  */
 import { useLilius } from 'use-lilius';
-import {
-	format,
-	subMonths,
-	addMonths,
-	startOfDay,
-	isSameMonth,
-} from 'date-fns';
+import { format, startOfDay, isSameMonth } from 'date-fns';
 
 /**
  * WordPress dependencies
  */
-import { __, isRTL } from '@wordpress/i18n';
-import { arrowLeft, arrowRight } from '@wordpress/icons';
-import { dateI18n } from '@wordpress/date';
+import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 
 /**
@@ -23,9 +15,8 @@ import { useState } from '@wordpress/element';
  */
 import Calendar from './calendar';
 import type { DatePickerProps } from '../types';
-import { Wrapper, Navigator, NavigatorHeading } from './styles';
+import { Wrapper } from './styles';
 import { inputToDate } from '../utils';
-import Button from '../../button';
 import { TIMEZONELESS_FORMAT } from '../constants';
 
 /**
@@ -90,49 +81,11 @@ export function DatePicker( {
 			role="application"
 			aria-label={ __( 'Calendar' ) }
 		>
-			<Navigator>
-				<Button
-					icon={ isRTL() ? arrowRight : arrowLeft }
-					variant="tertiary"
-					aria-label={ __( 'View previous month' ) }
-					onClick={ () => {
-						viewPreviousMonth();
-						setFocusable( subMonths( focusable, 1 ) );
-						onMonthPreviewed?.(
-							format(
-								subMonths( viewing, 1 ),
-								TIMEZONELESS_FORMAT
-							)
-						);
-					} }
-				/>
-				<NavigatorHeading level={ 3 }>
-					<strong>
-						{ dateI18n(
-							'F',
-							viewing,
-							-viewing.getTimezoneOffset()
-						) }
-					</strong>{ ' ' }
-					{ dateI18n( 'Y', viewing, -viewing.getTimezoneOffset() ) }
-				</NavigatorHeading>
-				<Button
-					icon={ isRTL() ? arrowLeft : arrowRight }
-					variant="tertiary"
-					aria-label={ __( 'View next month' ) }
-					onClick={ () => {
-						viewNextMonth();
-						setFocusable( addMonths( focusable, 1 ) );
-						onMonthPreviewed?.(
-							format(
-								addMonths( viewing, 1 ),
-								TIMEZONELESS_FORMAT
-							)
-						);
-					} }
-				/>
-			</Navigator>
 			<Calendar
+				viewPreviousMonth={ viewPreviousMonth }
+				viewNextMonth={ viewNextMonth }
+				setFocusable={ setFocusable }
+				onMonthPreviewed={ onMonthPreviewed }
 				calendar={ calendar }
 				isInvalidDate={ isInvalidDate }
 				viewing={ viewing }
@@ -140,7 +93,6 @@ export function DatePicker( {
 				events={ events }
 				onDayClick={ ( day ) => {
 					setSelected( [ day ] );
-					setFocusable( day );
 					onChange?.(
 						format(
 							// Don't change the selected date's time fields.
@@ -158,7 +110,6 @@ export function DatePicker( {
 					);
 				} }
 				onDayKeyDown={ ( nextFocusable ) => {
-					setFocusable( nextFocusable );
 					if ( ! isSameMonth( nextFocusable, viewing ) ) {
 						setViewing( nextFocusable );
 						onMonthPreviewed?.(

--- a/packages/components/src/date-time/date/index.tsx
+++ b/packages/components/src/date-time/date/index.tsx
@@ -4,17 +4,10 @@
 import { useLilius } from 'use-lilius';
 import {
 	format,
-	isSameDay,
 	subMonths,
 	addMonths,
 	startOfDay,
-	isEqual,
-	addDays,
-	subWeeks,
-	addWeeks,
 	isSameMonth,
-	startOfWeek,
-	endOfWeek,
 } from 'date-fns';
 
 /**
@@ -28,15 +21,9 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import Day from './day';
+import Calendar from './calendar';
 import type { DatePickerProps } from '../types';
-import {
-	Wrapper,
-	Navigator,
-	NavigatorHeading,
-	Calendar,
-	DayOfWeek,
-} from './styles';
+import { Wrapper, Navigator, NavigatorHeading } from './styles';
 import { inputToDate } from '../utils';
 import Button from '../../button';
 import { TIMEZONELESS_FORMAT } from '../constants';
@@ -87,12 +74,6 @@ export function DatePicker( {
 	// Used to implement a roving tab index. Tracks the day that receives focus
 	// when the user tabs into the calendar.
 	const [ focusable, setFocusable ] = useState( startOfDay( date ) );
-
-	// Allows us to only programmatically focus() a day when focus was already
-	// within the calendar. This stops us stealing focus from e.g. a TimePicker
-	// input.
-	const [ isFocusWithinCalendar, setIsFocusWithinCalendar ] =
-		useState( false );
 
 	// Update internal state when currentDate prop changes.
 	const [ prevCurrentDate, setPrevCurrentDate ] = useState( currentDate );
@@ -152,113 +133,41 @@ export function DatePicker( {
 				/>
 			</Navigator>
 			<Calendar
-				onFocus={ () => setIsFocusWithinCalendar( true ) }
-				onBlur={ () => setIsFocusWithinCalendar( false ) }
-			>
-				{ calendar[ 0 ][ 0 ].map( ( day ) => (
-					<DayOfWeek key={ day.toString() }>
-						{ dateI18n( 'D', day, -day.getTimezoneOffset() ) }
-					</DayOfWeek>
-				) ) }
-				{ calendar[ 0 ].map( ( week ) =>
-					week.map( ( day, index ) => {
-						if ( ! isSameMonth( day, viewing ) ) {
-							return null;
-						}
-						return (
-							<Day
-								key={ day.toString() }
-								day={ day }
-								column={ index + 1 }
-								isSelected={ isSelected( day ) }
-								isFocusable={ isEqual( day, focusable ) }
-								isFocusAllowed={ isFocusWithinCalendar }
-								isToday={ isSameDay( day, new Date() ) }
-								isInvalid={
-									isInvalidDate ? isInvalidDate( day ) : false
-								}
-								numEvents={
-									events.filter( ( event ) =>
-										isSameDay( event.date, day )
-									).length
-								}
-								onClick={ () => {
-									setSelected( [ day ] );
-									setFocusable( day );
-									onChange?.(
-										format(
-											// Don't change the selected date's time fields.
-											new Date(
-												day.getFullYear(),
-												day.getMonth(),
-												day.getDate(),
-												date.getHours(),
-												date.getMinutes(),
-												date.getSeconds(),
-												date.getMilliseconds()
-											),
-											TIMEZONELESS_FORMAT
-										)
-									);
-								} }
-								onKeyDown={ ( event ) => {
-									let nextFocusable;
-									if ( event.key === 'ArrowLeft' ) {
-										nextFocusable = addDays(
-											day,
-											isRTL() ? 1 : -1
-										);
-									}
-									if ( event.key === 'ArrowRight' ) {
-										nextFocusable = addDays(
-											day,
-											isRTL() ? -1 : 1
-										);
-									}
-									if ( event.key === 'ArrowUp' ) {
-										nextFocusable = subWeeks( day, 1 );
-									}
-									if ( event.key === 'ArrowDown' ) {
-										nextFocusable = addWeeks( day, 1 );
-									}
-									if ( event.key === 'PageUp' ) {
-										nextFocusable = subMonths( day, 1 );
-									}
-									if ( event.key === 'PageDown' ) {
-										nextFocusable = addMonths( day, 1 );
-									}
-									if ( event.key === 'Home' ) {
-										nextFocusable = startOfWeek( day );
-									}
-									if ( event.key === 'End' ) {
-										nextFocusable = startOfDay(
-											endOfWeek( day )
-										);
-									}
-									if ( nextFocusable ) {
-										event.preventDefault();
-										setFocusable( nextFocusable );
-										if (
-											! isSameMonth(
-												nextFocusable,
-												viewing
-											)
-										) {
-											setViewing( nextFocusable );
-											onMonthPreviewed?.(
-												format(
-													nextFocusable,
-													TIMEZONELESS_FORMAT
-												)
-											);
-										}
-									}
-								} }
-							/>
+				calendar={ calendar }
+				isInvalidDate={ isInvalidDate }
+				viewing={ viewing }
+				isSelected={ isSelected }
+				events={ events }
+				onDayClick={ ( day ) => {
+					setSelected( [ day ] );
+					setFocusable( day );
+					onChange?.(
+						format(
+							// Don't change the selected date's time fields.
+							new Date(
+								day.getFullYear(),
+								day.getMonth(),
+								day.getDate(),
+								date.getHours(),
+								date.getMinutes(),
+								date.getSeconds(),
+								date.getMilliseconds()
+							),
+							TIMEZONELESS_FORMAT
+						)
+					);
+				} }
+				onDayKeyDown={ ( nextFocusable ) => {
+					setFocusable( nextFocusable );
+					if ( ! isSameMonth( nextFocusable, viewing ) ) {
+						setViewing( nextFocusable );
+						onMonthPreviewed?.(
+							format( nextFocusable, TIMEZONELESS_FORMAT )
 						);
-					} )
-				) }
-			</Calendar>
+					}
+				} }
+				focusable={ focusable }
+			/>
 		</Wrapper>
 	);
 }

--- a/packages/components/src/date-time/date/styles.ts
+++ b/packages/components/src/date-time/date/styles.ts
@@ -18,6 +18,7 @@ export const Wrapper = styled.div`
 
 export const Navigator = styled( HStack )`
 	margin-bottom: ${ space( 4 ) };
+	justify-content: space-between;
 `;
 
 export const NavigatorHeading = styled( Heading )`

--- a/packages/components/src/date-time/date/styles.ts
+++ b/packages/components/src/date-time/date/styles.ts
@@ -34,7 +34,13 @@ export const Calendar = styled.div`
 	display: grid;
 	grid-template-columns: 0.5fr repeat( 5, 1fr ) 0.5fr;
 	justify-items: center;
-	row-gap: ${ space( 2 ) };
+`;
+
+export const DateRangeWrapper = styled.div`
+	display: flex;
+	flex-flow: row wrap;
+	gap: ${ space( 7 ) };
+	justify-content: center;
 `;
 
 export const DayOfWeek = styled.div`

--- a/packages/components/src/date-time/date/styles.ts
+++ b/packages/components/src/date-time/date/styles.ts
@@ -16,6 +16,31 @@ export const Wrapper = styled.div`
 	box-sizing: border-box;
 `;
 
+export const ButtonWrapper = styled.div< {
+	isBoundary: boolean;
+	isSelected: boolean;
+} >`
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	height: ${ space( 8 ) };
+	width: ${ space( 8 ) };
+
+	${ ( props ) =>
+		! props.isBoundary &&
+		`background-color: ${
+			props.isSelected ? COLORS.theme.gray[ 600 ] : COLORS.white
+		};
+		&&& button {
+			color: ${ props.isSelected ? COLORS.white : COLORS.theme.foreground };
+			background-color: transparent;
+		};
+		` };
+
+	${ ( props ) =>
+		props.isBoundary && `background-color: ${ COLORS.theme.accent };` };
+`;
+
 export const Navigator = styled( HStack )`
 	margin-bottom: ${ space( 4 ) };
 	justify-content: space-between;
@@ -31,7 +56,6 @@ export const NavigatorHeading = styled( Heading )`
 `;
 
 export const Calendar = styled.div`
-	column-gap: ${ space( 2 ) };
 	display: grid;
 	grid-template-columns: 0.5fr repeat( 5, 1fr ) 0.5fr;
 	justify-items: center;
@@ -70,6 +94,8 @@ export const DayButton = styled( Button, {
 	grid-column: ${ ( props ) => props.column };
 	position: relative;
 	justify-content: center;
+	align-items: center;
+	padding: ${ space( 1 ) };
 
 	${ ( props ) =>
 		props.column === 1 &&

--- a/packages/components/src/date-time/date/styles.ts
+++ b/packages/components/src/date-time/date/styles.ts
@@ -19,6 +19,8 @@ export const Wrapper = styled.div`
 export const ButtonWrapper = styled.div< {
 	isBoundary: boolean;
 	isSelected: boolean;
+	isToday: boolean;
+	selectionMode: 'single' | 'range';
 } >`
 	display: flex;
 	justify-content: center;
@@ -27,8 +29,9 @@ export const ButtonWrapper = styled.div< {
 	width: ${ space( 8 ) };
 
 	${ ( props ) =>
-		! props.isBoundary &&
-		`background-color: ${
+		props.selectionMode === 'range' &&
+		`
+		background-color: ${
 			props.isSelected ? COLORS.theme.gray[ 600 ] : COLORS.white
 		};
 		&&& button {
@@ -38,7 +41,17 @@ export const ButtonWrapper = styled.div< {
 		` };
 
 	${ ( props ) =>
-		props.isBoundary && `background-color: ${ COLORS.theme.accent };` };
+		props.selectionMode === 'range' &&
+		props.isBoundary &&
+		`background-color: ${ COLORS.theme.accent };` };
+
+	${ ( props ) =>
+		props.selectionMode === 'range' &&
+		! props.isSelected &&
+		props.isToday &&
+		`
+		background: ${ COLORS.gray[ 200 ] };
+		` }
 `;
 
 export const Navigator = styled( HStack )`
@@ -84,12 +97,19 @@ export const DayOfWeek = styled.div`
 
 export const DayButton = styled( Button, {
 	shouldForwardProp: ( prop: string ) =>
-		! [ 'column', 'isSelected', 'isToday', 'hasEvents' ].includes( prop ),
+		! [
+			'column',
+			'isSelected',
+			'isToday',
+			'hasEvents',
+			'selectionMode',
+		].includes( prop ),
 } )< {
 	column: number;
 	isSelected: boolean;
 	isToday: boolean;
 	hasEvents: boolean;
+	selectionMode: 'single' | 'range';
 } >`
 	grid-column: ${ ( props ) => props.column };
 	position: relative;
@@ -116,7 +136,10 @@ export const DayButton = styled( Button, {
 		` }
 
 	&&& {
-		border-radius: ${ CONFIG.radiusRound };
+		${ ( props ) =>
+			`border-radius: ${
+				props.selectionMode === 'range' ? '0' : CONFIG.radiusRound
+			};` };
 		height: ${ space( 7 ) };
 		width: ${ space( 7 ) };
 

--- a/packages/components/src/date-time/index.ts
+++ b/packages/components/src/date-time/index.ts
@@ -2,8 +2,9 @@
  * Internal dependencies
  */
 import { default as DatePicker } from './date';
+import { default as DateRange } from './date-range';
 import { default as TimePicker } from './time';
 import { default as DateTimePicker } from './date-time';
 
-export { DatePicker, TimePicker };
+export { DatePicker, TimePicker, DateRange };
 export default DateTimePicker;

--- a/packages/components/src/date-time/stories/date-range.story.tsx
+++ b/packages/components/src/date-time/stories/date-range.story.tsx
@@ -41,9 +41,9 @@ const Template: StoryFn< typeof DateRange > = ( {
 		<DateRange
 			{ ...args }
 			currentDate={ date }
-			onChange={ ( newDate ) => {
-				setDate( newDate );
-				onChange?.( newDate );
+			onChange={ ( startDate, endDate ) => {
+				setDate( startDate );
+				onChange?.( startDate, endDate );
 			} }
 		/>
 	);

--- a/packages/components/src/date-time/stories/date-range.story.tsx
+++ b/packages/components/src/date-time/stories/date-range.story.tsx
@@ -1,0 +1,78 @@
+/**
+ * External dependencies
+ */
+import type { Meta, StoryFn } from '@storybook/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import DateRange from '../date-range';
+import { daysFromNow, isWeekend } from './utils';
+
+const meta: Meta< typeof DateRange > = {
+	title: 'Components/DateRange',
+	component: DateRange,
+	argTypes: {
+		currentDate: { control: 'date' },
+		onChange: { action: 'onChange', control: { type: null } },
+	},
+	parameters: {
+		controls: { expanded: true },
+		docs: { canvas: { sourceState: 'shown' } },
+	},
+};
+export default meta;
+
+const Template: StoryFn< typeof DateRange > = ( {
+	currentDate,
+	onChange,
+	...args
+} ) => {
+	const [ date, setDate ] = useState( currentDate );
+	useEffect( () => {
+		setDate( currentDate );
+	}, [ currentDate ] );
+	return (
+		<DateRange
+			{ ...args }
+			currentDate={ date }
+			onChange={ ( newDate ) => {
+				setDate( newDate );
+				onChange?.( newDate );
+			} }
+		/>
+	);
+};
+
+export const Default: StoryFn< typeof DateRange > = Template.bind( {} );
+
+export const WithEvents: StoryFn< typeof DateRange > = Template.bind( {} );
+WithEvents.args = {
+	currentDate: new Date(),
+	events: [
+		{ date: daysFromNow( 2 ) },
+		{ date: daysFromNow( 4 ) },
+		{ date: daysFromNow( 6 ) },
+		{ date: daysFromNow( 8 ) },
+	],
+};
+
+export const WithInvalidDates: StoryFn< typeof DateRange > = Template.bind(
+	{}
+);
+WithInvalidDates.args = {
+	currentDate: new Date(),
+	isInvalidDate: isWeekend,
+};
+
+export const WithRange: StoryFn< typeof DateRange > = Template.bind( {} );
+WithRange.args = {
+	currentDate: new Date(),
+	rangeStart: daysFromNow( 2 ),
+	rangeEnd: daysFromNow( 8 ),
+};

--- a/packages/components/src/date-time/stories/date-range.story.tsx
+++ b/packages/components/src/date-time/stories/date-range.story.tsx
@@ -13,6 +13,7 @@ import { useState, useEffect } from '@wordpress/element';
  */
 import DateRange from '../date-range';
 import { daysFromNow, isWeekend } from './utils';
+import { inputToDate } from '../utils';
 
 const meta: Meta< typeof DateRange > = {
 	title: 'Components/DateRange',
@@ -34,15 +35,31 @@ const Template: StoryFn< typeof DateRange > = ( {
 	...args
 } ) => {
 	const [ date, setDate ] = useState( currentDate );
+	const [ rangeEnd, setRangeEnd ] = useState< Date | null >( null );
+	const [ rangeStart, setRangeStart ] = useState< Date | null >( null );
+
+	useEffect( () => {
+		setDate( currentDate );
+		if ( ! args.rangeStart || ! args.rangeEnd ) {
+			return;
+		}
+		setRangeEnd( inputToDate( args.rangeEnd ) );
+		setRangeStart( inputToDate( args.rangeStart ) );
+	}, [ args.rangeStart, args.rangeEnd, currentDate ] );
+
 	useEffect( () => {
 		setDate( currentDate );
 	}, [ currentDate ] );
 	return (
 		<DateRange
 			{ ...args }
+			rangeEnd={ rangeEnd }
+			rangeStart={ rangeStart }
 			currentDate={ date }
 			onChange={ ( startDate, endDate ) => {
 				setDate( startDate );
+				setRangeEnd( endDate );
+				setRangeStart( startDate );
 				onChange?.( startDate, endDate );
 			} }
 		/>

--- a/packages/components/src/date-time/types.ts
+++ b/packages/components/src/date-time/types.ts
@@ -166,6 +166,8 @@ export type DateRangeProps = Omit< DatePickerProps, 'onChange' > & {
 	 * The last selectable date in the calendar.
 	 */
 	lastSelectableDate?: Date | string | number | null;
+
+	numberOfMonths?: number;
 };
 
 export type DateTimePickerProps = Omit< DatePickerProps, 'onChange' > &

--- a/packages/components/src/date-time/types.ts
+++ b/packages/components/src/date-time/types.ts
@@ -134,11 +134,37 @@ export type DatePickerProps = {
 	 * @default 0
 	 */
 	startOfWeek?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+};
 
-	// TODO: add a new prop type for the following props
+export type DateRangeProps = Omit< DatePickerProps, 'onChange' > & {
+	/**
+	 * The current date and time at initialization. Optionally pass in a `null`
+	 */
+	currentDate?: Date | string | number | null;
+	/**
+	 * The function called when a new date range has been selected. It is
+	 * passed the date and time as an argument.
+	 */
+	onChange?: ( startDate: string | null, endDate: string | null ) => void;
+
+	/**
+	 * The start date of the range.
+	 */
 	rangeStart?: Date | string | number | null;
+
+	/**
+	 * The end date of the range.
+	 */
 	rangeEnd?: Date | string | number | null;
+
+	/**
+	 * The first selectable date in the calendar.
+	 */
 	firstSelectableDate?: Date | string | number | null;
+
+	/**
+	 * The last selectable date in the calendar.
+	 */
 	lastSelectableDate?: Date | string | number | null;
 };
 

--- a/packages/components/src/date-time/types.ts
+++ b/packages/components/src/date-time/types.ts
@@ -134,6 +134,12 @@ export type DatePickerProps = {
 	 * @default 0
 	 */
 	startOfWeek?: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+	// TODO: add a new prop type for the following props
+	rangeStart?: Date | string | number | null;
+	rangeEnd?: Date | string | number | null;
+	firstSelectableDate?: Date | string | number | null;
+	lastSelectableDate?: Date | string | number | null;
 };
 
 export type DateTimePickerProps = Omit< DatePickerProps, 'onChange' > &

--- a/packages/components/src/date-time/types.ts
+++ b/packages/components/src/date-time/types.ts
@@ -145,7 +145,7 @@ export type DateRangeProps = Omit< DatePickerProps, 'onChange' > & {
 	 * The function called when a new date range has been selected. It is
 	 * passed the date and time as an argument.
 	 */
-	onChange?: ( startDate: string | null, endDate: string | null ) => void;
+	onChange?: ( startDate: Date | null, endDate: Date | null ) => void;
 
 	/**
 	 * The start date of the range.

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -69,7 +69,12 @@ export {
 export { ConfirmDialog as __experimentalConfirmDialog } from './confirm-dialog';
 export { default as CustomSelectControl } from './custom-select-control';
 export { default as Dashicon } from './dashicon';
-export { default as DateTimePicker, DatePicker, TimePicker } from './date-time';
+export {
+	default as DateTimePicker,
+	DatePicker,
+	TimePicker,
+	DateRange,
+} from './date-time';
 export { default as __experimentalDimensionControl } from './dimension-control';
 export { default as Disabled } from './disabled';
 export { DisclosureContent as __unstableDisclosureContent } from './disclosure';


### PR DESCRIPTION
## This is a WIP and not yet applied any design

PT: pejTkB-1zd-p2

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

- Refactor Day component into a separate file to be reused
- Created a DateRange component that works for a date range selection, which is still mostly a copy of the date picker
- Create base stories for DateRange

## Why?

Add a date range picker

## Testing Instructions

- Checkout my fork
- Choose the right node version `nvm use`
- Install `npm i`
- Run storybook `npm run storybook:dev`
- Search for `DateRange`
- Ensure the third example marks several dates as selected



### Testing Instructions for Keyboard

n/a

## Screenshots or screencast <!-- if applicable -->







https://github.com/user-attachments/assets/798e3e60-8a25-48f6-bad5-fef4801ddac7



